### PR TITLE
Add Streamlit dashboard app with deployment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app.py
+++ b/app.py
@@ -1,0 +1,159 @@
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+
+st.set_page_config(page_title="データ可視化ダッシュボード", layout="wide")
+
+
+def initialize_session_state():
+    if "user_inputs" not in st.session_state:
+        st.session_state.user_inputs = {
+            "name": "ゲスト",
+            "age": 30,
+            "interest": "データサイエンス",
+            "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+
+
+def update_session_state(name: str, age: int, interest: str):
+    st.session_state.user_inputs.update(
+        {
+            "name": name,
+            "age": age,
+            "interest": interest,
+            "last_updated": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    )
+
+
+def sidebar_inputs():
+    st.sidebar.header("ユーザー設定")
+    name = st.sidebar.text_input("名前", value=st.session_state.user_inputs["name"])
+    age = st.sidebar.number_input(
+        "年齢", min_value=0, max_value=120, value=st.session_state.user_inputs["age"], step=1
+    )
+    interest_options = ["データサイエンス", "機械学習", "Web開発", "可視化", "ビジネス分析"]
+    try:
+        default_index = interest_options.index(st.session_state.user_inputs["interest"])
+    except ValueError:
+        default_index = 0
+    interest = st.sidebar.selectbox(
+        "関心領域",
+        options=interest_options,
+        index=default_index,
+    )
+    if st.sidebar.button("セッション更新"):
+        update_session_state(name, int(age), interest)
+        st.sidebar.success("セッション情報を更新しました！")
+
+
+def generate_sample_data():
+    dates = pd.date_range(datetime.now().date(), periods=30)
+    data = pd.DataFrame(
+        {
+            "date": dates,
+            "value": np.random.randint(50, 150, size=len(dates)),
+            "category": np.random.choice(["A", "B", "C"], size=len(dates)),
+        }
+    )
+    return data
+
+
+def render_charts(data: pd.DataFrame):
+    st.subheader("時系列ラインチャート (Plotly)")
+    line_fig = px.line(data, x="date", y="value", color="category", title="サンプル時系列データ")
+    st.plotly_chart(line_fig, use_container_width=True)
+
+    st.subheader("カテゴリ別バーチャート (Matplotlib)")
+    category_counts = data.groupby("category")["value"].mean().reset_index()
+    fig, ax = plt.subplots()
+    ax.bar(category_counts["category"], category_counts["value"], color=["#1f77b4", "#ff7f0e", "#2ca02c"])
+    ax.set_xlabel("カテゴリ")
+    ax.set_ylabel("平均値")
+    ax.set_title("カテゴリ別平均値")
+    st.pyplot(fig)
+
+
+def render_map():
+    st.subheader("位置情報マップ")
+    map_data = pd.DataFrame(
+        {
+            "lat": [35.6804, 34.6937, 35.0116],
+            "lon": [139.7690, 135.5022, 135.7681],
+            "city": ["東京", "大阪", "京都"],
+        }
+    )
+    st.map(map_data, zoom=5)
+
+
+def render_table(data: pd.DataFrame):
+    st.subheader("データプレビュー")
+    st.dataframe(data.head(10))
+
+
+def render_image():
+    st.subheader("イメージギャラリー")
+    gradient = np.linspace(0, 1, 256)
+    gradient = np.tile(gradient, (256, 1))
+    colored_image = np.dstack((gradient, gradient[::-1], np.ones_like(gradient)))
+    st.image(colored_image, caption="NumPy で生成したグラデーション画像", use_column_width=True)
+
+
+def render_session_state_summary():
+    st.subheader("セッション情報")
+    st.json(st.session_state.user_inputs)
+
+
+def render_file_uploader():
+    st.subheader("CSV ファイルアップロード")
+    uploaded_file = st.file_uploader("CSV ファイルを選択", type="csv")
+    if uploaded_file is not None:
+        try:
+            uploaded_df = pd.read_csv(uploaded_file)
+            st.success("ファイルを読み込みました")
+            st.dataframe(uploaded_df)
+        except Exception as error:  # pylint: disable=broad-except
+            st.error(f"CSV の読み込みに失敗しました: {error}")
+
+
+def render_summary_metrics(data: pd.DataFrame):
+    st.subheader("主要指標")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("データ件数", len(data))
+    col2.metric("平均値", f"{data['value'].mean():.1f}")
+    col3.metric("最大値", int(data['value'].max()))
+
+
+def render_layout():
+    st.title("Streamlit データダッシュボード")
+    st.caption("サイドバーからパラメータを調整し、可視化やデータを探索してください。")
+
+    data = generate_sample_data()
+
+    render_summary_metrics(data)
+
+    chart_col, table_col = st.columns((2, 1))
+    with chart_col:
+        render_charts(data)
+        render_map()
+    with table_col:
+        render_table(data)
+        render_image()
+
+    render_file_uploader()
+    render_session_state_summary()
+
+
+def main():
+    initialize_session_state()
+    sidebar_inputs()
+    render_layout()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.33.0
+pandas>=2.2.0
+numpy>=1.26.0
+matplotlib>=3.8.0
+plotly>=5.19.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "builds": [
+    {
+      "src": "app.py",
+      "use": "@vercel/python"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "app.py"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create a Streamlit dashboard app with sidebar controls, charts, map, image rendering, file uploads, and session state management
- add the required Python dependencies for running the dashboard
- include Vercel deployment routing and ignore Python cache files

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68d75b14872083278058a7cd98ff3b21